### PR TITLE
2025-11: Update Build Process

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ More information about the project is available on the Gotham Digital Science bl
 ## Installation
 
 Grab the latest version of afl from the [afl homepage](https://lcamtuf.coredump.cx/afl/) and compile it.
+At the time of writing, the latest version is [afl 2.52b](https://lcamtuf.coredump.cx/afl/releases/afl-2.52b.tgz).
 
-Update the constants of the scripts in the `fuzz` folder so they point to the desired afl compiler.
+Set the `AFL_PATH` environment variable with the folder containing the afl binaries: `export AFL_PATH=/usr/local/src/afl-2.52b`
+Extend the `PATH` environment variable with `AFL_PATH`: `export PATH=$PATH:$AFL_PATH`
+Alternatively, update the constants of the scripts in the `fuzz` folder so they point to the desired afl compiler.
 
 Run the following command which automatically downloads different versions of mbed TLS, patches them, compiles the code, and sets everything up for fuzzing.
 

--- a/crash-analysis.sh
+++ b/crash-analysis.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # To find crash files, use a command such as the following:
 # find . -name 'id*' -type f | grep crashes | sort > crash_files.txt

--- a/fuzz/compile.sh
+++ b/fuzz/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Variable AFL_CC is already taken!
 # Add afl-clang-fast to your PATH and/or adapt the following variable:
@@ -21,6 +21,10 @@ export AFL_DONT_OPTIMIZE=0
 
 cd ..
 find . -name CMakeCache.txt -type f -print | xargs /bin/rm -f
-cmake -DCMAKE_C_COMPILER="$AFL_CC_BIN" -DBUILD_SHARED_LIBS=Off -DENABLE_TESTING=Off -DCMAKE_BUILD_TYPE=Debug --clean-first .
+cmake -DCMAKE_C_COMPILER="$AFL_CC_BIN" \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DENABLE_TESTING=OFF \
+      -DCMAKE_BUILD_TYPE=Debug \
+      .
 make clean all
 

--- a/fuzz/fuzz.sh
+++ b/fuzz/fuzz.sh
@@ -1,19 +1,19 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-readonly SELFTLS_BIN="../selftls"
+readonly SELFTLS_BIN='../selftls'
 # Add afl-fuzz to your PATH or the change the following variable:
-readonly AFL_FUZZ="afl-fuzz"
-readonly RAMDISK_PATH="/tmp/afl-ramdisk/mbedtls"
+readonly AFL_FUZZ='afl-fuzz'
+readonly RAMDISK_PATH='/tmp/afl-ramdisk/mbedtls'
 # The following parameter is the peak virtual memory use in MiB of selftls.
 # The parameter is only necessary for ASAN-enabled builds on x86-64.
 # You can determine the value for your selftls using the tool from
 # http://jwilk.net/software/recidivm
 # by running 'recidivm -u M selftls'.
-readonly MEM_REQUIRED="300000000"
+readonly MEM_REQUIRED='300000000'
 # If you want to use the experimental cgroups script under Linux for
 # ASAN-enabled builds on x86-64, set the following path correctly and
 # uncomment the relevant code further down:
-readonly AFL_ASAN_CGROUPS="${HOME}/afl/afl-2.??b/experimental/asan_cgroups/limit_memory.sh"
+readonly AFL_ASAN_CGROUPS="${AFL_PATH}/experimental/asan_cgroups/limit_memory.sh"
 # Set to 0, if you do not have an ASAN-enabled build.
 export AFL_USE_ASAN=1
 
@@ -34,7 +34,7 @@ usage() {
 	mbedtls-fuzz v3.0
 	Fabian Foerg <ffoerg@gdssecurity.com>
 	https://blog.gdssecurity.com/labs/2015/9/21/fuzzing-the-mbed-tls-library.html
-	Copyright 2015 Gotham Digital Science
+	Copyright 2015-2025 Gotham Digital Science
 	EOF
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,14 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-readonly ARCHIVE_SUFFIX='-gpl.tgz'
+readonly ARCHIVE_SUFFIX='.tar.gz'
 readonly MBEDTLS_2_3='mbedtls-2.3.0'
-readonly SHA_256_2_3='21237014f779bde70b2d71399cc1ea53365eb7f10cdd74a13ee6329a1910cb49'
+readonly SHA_256_2_3='1614ee70be99a18ca8298148308fb725aad4ad31c569438bb51655a4999b14f9'
 readonly MBEDTLS_2_1='mbedtls-2.1.5'
-readonly SHA_256_2_1='119ff3ee2788a2c5f0604b247bdffd401c439c8e551561cbb4b1f9d3a21a120d'
+readonly SHA_256_2_1='01e1325896cbeea55ac50b94e3818218a5bfff065e5b6e7a2a12987f5e187026'
 readonly MBEDTLS_1_3='mbedtls-1.3.17'
-readonly SHA_256_1_3='f5beb43e850283915e3e0f8d37495eade3bfb5beedfb61e7b8da70d4c68edb82'
+readonly SHA_256_1_3='5a80deaa77f098733861b53cbabd392cee425b54109c90a6a2142a9662691aa7'
 readonly MBEDTLS_A=( "$MBEDTLS_2_3" "$MBEDTLS_2_1" "$MBEDTLS_1_3" )
 readonly SHA_256_A=( "$SHA_256_2_3" "$SHA_256_2_1" "$SHA_256_1_3" )
+readonly FOLDER_PREFIX='mbedtls-'
 readonly NO_TIME=1
 
 main() {
@@ -18,7 +19,7 @@ main() {
 
     for i in "${!MBEDTLS_A[@]}"; do
         # download if necessary
-        wget -nc https://tls.mbed.org/download/"${MBEDTLS_A[$i]}${ARCHIVE_SUFFIX}"
+        wget -nc https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/"${MBEDTLS_A[$i]}${ARCHIVE_SUFFIX}"
 
         # validate the checksum of the code archives
         CHECKSUM=$(shasum -a 256 "${MBEDTLS_A[$i]}${ARCHIVE_SUFFIX}")
@@ -40,24 +41,24 @@ main() {
         fi
 
         # copy fuzzing code and configuration
-        cp -R fuzz "${MBEDTLS_A[$i]}"
-        cp "selftls-${VERSION}.c" "${MBEDTLS_A[$i]}/fuzz/selftls.c"
+        cp -R fuzz "${FOLDER_PREFIX}${MBEDTLS_A[$i]}"
+        cp "selftls-${VERSION}.c" "${FOLDER_PREFIX}${MBEDTLS_A[$i]}/fuzz/selftls.c"
 
         # patch CMakeLists
-        pushd "${MBEDTLS_A[$i]}" && patch -p1 < "../CMakeLists-${VERSION}.patch"; popd
+        pushd "${FOLDER_PREFIX}${MBEDTLS_A[$i]}" && patch -p1 < "../CMakeLists-${VERSION}.patch"; popd
 
         # make sure TLS time field is constant
         if [[ "$NO_TIME" = "1" ]]; then
-            cp "config-${VERSION}.h" "${MBEDTLS_A[$i]}/include/${INCLUDE_DIR}/config.h"
+            cp "config-${VERSION}.h" "${FOLDER_PREFIX}${MBEDTLS_A[$i]}/include/${INCLUDE_DIR}/config.h"
         else
-            pushd "${MBEDTLS_A[$i]}" && patch -p1 < "../time-${VERSION}.patch"; popd
+            pushd "${FOLDER_PREFIX}${MBEDTLS_A[$i]}" && patch -p1 < "../time-${VERSION}.patch"; popd
         fi
 
         # compile the code
-        pushd "${MBEDTLS_A[$i]}/fuzz" && ./compile.sh; popd
+        pushd "${FOLDER_PREFIX}${MBEDTLS_A[$i]}/fuzz" && ./compile.sh; popd
     done
 
-    echo -e "\n  ************\n  If everything compiled correctly, go into one of the 'mbedtls-2.?.?/fuzz/' folders and run './fuzz.sh'\n  ************"
+    echo -e "\n  ************\n  If everything compiled correctly, go into one of the 'mbedtls-?.?.?/fuzz/' folders and run './fuzz.sh'\n  ************"
 }
 
 main "$@"


### PR DESCRIPTION
The project has not been updated in about a decade.

Update the build process to support the following:
- The same Mbed TLS versions downloaded from GitHub, since the original source website has been shut down
- The latest version of [lcamtuf's afl](https://lcamtuf.coredump.cx/afl/) 2.52b
- Modern CMake versions (tested with 3.28.3)